### PR TITLE
Additional Carousel Routes & Changes to Title Details Route

### DIFF
--- a/database/controllers/relatedTitles.js
+++ b/database/controllers/relatedTitles.js
@@ -76,7 +76,8 @@ const findRelatedTitles = async (req, res) => {
             let currentRecommendation = {
               type: response.data.results[i].media_type,
               tmdb_id: response.data.results[i].id,
-              poster_path: 'https://image.tmdb.org/t/p/w500' + response.data.results[i].poster_path
+              poster_path: 'https://image.tmdb.org/t/p/w500' + response.data.results[i].poster_path,
+              saved_by_user: false
             }
             if (priorityMovies[JSON.stringify(response.data.results[i].id)] && !orderModified) {
               finalResults.unshift(currentRecommendation);

--- a/database/controllers/savedTitles.js
+++ b/database/controllers/savedTitles.js
@@ -5,7 +5,9 @@ const findSavedTitles = async (req, res) => {
   //console.log('req is hitting controller: ', req.query.user_id);
   await Saved_Title.find({ user_id: req.query.user_id })
     .then((savedTitles) => {
-      //console.log('success getting saved titles: ', savedTitles)
+      for (var i = 0; i < savedTitles.length; i++) {
+        savedTitles[i]._doc.saved_by_user = true;
+      }
       res.status(200).send(savedTitles.reverse())
     })
     .catch((error) => {

--- a/database/controllers/spielbergTitles.js
+++ b/database/controllers/spielbergTitles.js
@@ -1,0 +1,138 @@
+const Saved_Title = require('../models/savedTitle.js');
+const axios = require('axios').default;
+
+
+const findSpielbergTitles = async (req, res) => {
+  let titles = [
+    {
+      "type": "movie",
+      "tmdb_id": 329,
+      "poster_path": "https://image.tmdb.org/t/p/w500/oU7Oq2kFAAlGqbU4VoAE36g4hoI.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 857,
+      "poster_path": "https://image.tmdb.org/t/p/w500/1wY4psJ5NVEhCuOYROwLH2XExM2.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 333339,
+      "poster_path": "https://image.tmdb.org/t/p/w500/pU1ULUq8D3iRxl1fdX2lZIzdHuI.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 424,
+      "poster_path": "https://image.tmdb.org/t/p/w500/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 640,
+      "poster_path": "https://image.tmdb.org/t/p/w500/ctjEj2xM32OvBXCq8zAdK3ZrsAj.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 1895,
+      "poster_path": "https://image.tmdb.org/t/p/w500/xfSAoBEm9MNBjmlNcDYLvLSMlnq.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 85,
+      "poster_path": "https://image.tmdb.org/t/p/w500/awUGN7ZCNq2EUTdpVaHDX23anOZ.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 601,
+      "poster_path": "https://image.tmdb.org/t/p/w500/an0nD6uq6byfxXCfk6lQBzdL2J1.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 612,
+      "poster_path": "https://image.tmdb.org/t/p/w500/iUekaw96QLInZpsNwRTlRKrZgwm.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 296098,
+      "poster_path": "https://image.tmdb.org/t/p/w500/bORlvwnVJE1Z6yIg96qnLLY3LJQ.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 267935,
+      "poster_path": "https://image.tmdb.org/t/p/w500/4zawxGJIH43DcoGG9Ui0WoIcrQC.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 511809,
+      "poster_path": "https://image.tmdb.org/t/p/w500/zeAZTPxV5xZRNEX3rZotnsp7IVo.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 180,
+      "poster_path": "https://image.tmdb.org/t/p/w500/ccqpHq5tk5W4ymbSbuoy4uYOxFI.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 873,
+      "poster_path": "https://image.tmdb.org/t/p/w500/ziosRyziefrmEmAMIswpjQzvAur.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 576510,
+      "poster_path": "https://image.tmdb.org/t/p/w500/8YEuXYEw9MsqAhB8aw3cBevifbs.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 578,
+      "poster_path": "https://image.tmdb.org/t/p/w500/s2xcqSFfT6F7ZXHxowjxfG0yisT.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 72976,
+      "poster_path": "https://image.tmdb.org/t/p/w500/oosQMP9sh9LF2xR2eKcQ1iSscWM.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 74,
+      "poster_path": "https://image.tmdb.org/t/p/w500/oZmJ6hD2dc6zLCIPgw8onPMo0QC.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 15301,
+      "poster_path": "https://image.tmdb.org/t/p/w500/sDWARc5aYTUKE8Y2FIGVgWXuI4K.jpg"
+    },
+    {
+      "type": "movie",
+      "tmdb_id": 879,
+      "poster_path": "https://image.tmdb.org/t/p/w500/a6rB1lGXoGms7gWxRfJneQmAjNV.jpg"
+    },
+  ]
+
+  let userSavedTitles = {};
+
+  await Saved_Title.find({user_id: req.query.user_id})
+    .then((savedTitles) => {
+      for (var i = 0; i < savedTitles.length; i++) {
+        userSavedTitles[savedTitles[i].tmdb_id] = true;
+      }
+    })
+    .catch((error) => {
+      res.status(400).send('Error while finding user\'s saved titles: ' + error);
+      return;
+    })
+
+  let finalResults = [];
+
+  for (var i = 0; i < titles.length; i++) {
+      let currentRecommendation = {
+        type: titles[i].type,
+        tmdb_id: titles[i].tmdb_id,
+        poster_path: titles[i].poster_path,
+        saved_by_user: userSavedTitles[titles[i].tmdb_id] || false
+      }
+      finalResults.push(currentRecommendation);
+  }
+
+  res.status(200).send(finalResults)
+
+}
+
+module.exports.findSpielbergTitles = findSpielbergTitles;

--- a/database/controllers/titleDetails.js
+++ b/database/controllers/titleDetails.js
@@ -1,0 +1,91 @@
+const Saved_Title = require('../models/savedTitle.js');
+const axios = require('axios').default;
+
+
+const findTitleDetails = async (req, res) => {
+  let userSavedTitles = {};
+  let saved_by_user;
+
+  await Saved_Title.findOne({user_id: req.query.user_id, tmdb_id: req.query.tmdb_id})
+    .then((savedTitle) => {
+      if (savedTitle) {
+        saved_by_user = true
+      } else {
+        saved_by_user = false
+      }
+    })
+    .catch((error) => {
+      res.status(400).send('Error while looking up title in user\'s saved titles list: ' + error);
+      return;
+    })
+
+  let searchField;
+  if (req.query.type === 'tv') {
+    searchField = 'tmdb_tv_id';
+  } else if (req.query.type === 'movie') {
+    searchField = 'tmdb_movie_id'
+  } else {
+    res.status(400).send('Invalid \'type\' input in search query.  Acceptable options are \'tv\' or \'movie\'')
+  }
+
+  await axios.get(`https://api.watchmode.com/v1/search/`, {
+      params: {
+        apiKey: process.env.WATCHMODE_API_KEY,
+        search_field: searchField,
+        search_value: req.query.tmdb_id,
+        types: 'tv,movie'
+      }
+    })
+      .then(async (response) => {
+        let imdb_id = response.data.title_results[0].imdb_id;
+
+        await axios.get(`http://www.omdbapi.com/`, {
+          params: {
+            apikey: process.env.OMDB_API_KEY,
+            i: imdb_id,
+            plot: 'full'
+          }
+        })
+          .then(async (response) => {
+
+            let newResponse = {
+              title: response.data.Title,
+              ratings: response.data.Ratings,
+              run_time: response.data.Runtime,
+              director: response.data.Director,
+              synopsis: response.data.Plot,
+              type: req.query.type,
+              tmdb_id: req.query.tmdb_id,
+              parental_rating: response.data.Rated,
+              release_date: response.data.Released,
+              genre: response.data.genre,
+              poster_path: 'https://i.imgur.com/7sR45d6.png',
+              saved_by_user
+            }
+
+            await axios.get(`https://api.themoviedb.org/3/${req.query.type}/${req.query.tmdb_id}`, {
+              params: {
+                api_key: process.env.TMDB_API_KEY
+              }
+            })
+              .then((omdbResponse) => {
+                if (omdbResponse && omdbResponse.data.poster_path) {
+                  newResponse.poster_path = `https://image.tmdb.org/t/p/w500${omdbResponse.data.poster_path}`
+                }
+              })
+              .catch((error) => {
+                res.status(400).send('Error while retrieving poster from TMDB API: ' + error);
+                return;
+              })
+
+            res.status(200).send(newResponse)
+          })
+      })
+      .catch((error) => {
+        res.status(400).send('Error while fetching IMDB ID from watchmode API: ' + error);
+        return;
+      })
+
+}
+
+module.exports.findTitleDetails = findTitleDetails;

--- a/database/controllers/trendingTitles.js
+++ b/database/controllers/trendingTitles.js
@@ -1,0 +1,49 @@
+const Saved_Title = require('../models/savedTitle.js');
+const axios = require('axios').default;
+
+
+const findTrendingTitles = async (req, res) => {
+  let visitedTitles = {};
+  let userSavedTitles = {};
+
+  await Saved_Title.find({user_id: req.query.user_id})
+    .then((savedTitles) => {
+      for (var i = 0; i < savedTitles.length; i++) {
+        userSavedTitles[savedTitles[i].tmdb_id] = true;
+      }
+    })
+    .catch((error) => {
+      res.status(400).send('Error while finding user\'s saved titles: ' + error);
+      return;
+    })
+
+  let finalResults = [];
+    await axios.get(`https://api.themoviedb.org/3/trending/all/week`, {
+      params: {
+        api_key: process.env.TMDB_API_KEY
+      }
+    })
+      .then((response) => {
+        for (var i = 0; i < response.data.results.length; i++) {
+          if (!visitedTitles[response.data.results[i].id]) {
+            let currentRecommendation = {
+              type: response.data.results[i].media_type,
+              tmdb_id: response.data.results[i].id,
+              poster_path: 'https://image.tmdb.org/t/p/w500' + response.data.results[i].poster_path,
+              saved_by_user: userSavedTitles[response.data.results[i].id] || false
+            }
+            finalResults.push(currentRecommendation);
+            visitedTitles[currentRecommendation.tmdb_id] = true;
+          }
+        }
+      })
+      .catch((error) => {
+        res.status(400).send('Error while fetching related ID\'s from watchmode API: ' + error);
+        return;
+      })
+
+  res.status(200).send(finalResults)
+
+}
+
+module.exports.findTrendingTitles = findTrendingTitles;

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,8 @@ const searchRoutes = require('./routes/searchRoutes.js');
 const thumbRatings = require('./routes/thumbRatings.js');
 const streamSources = require('./routes/streamSources.js');
 const streamRatings = require('./routes/streamRatings.js');
+const trendingTitles = require('./routes/trendingTitlesRoutes.js');
+const spielbergTitles = require('./routes/spielbergTitlesRoutes.js');
 
 
 //FOR FACEBOOK TESTING ONLY BECAUSE FACEBOOK LOGIN DOES NOT ACCEPT HTTP REQUESTS//
@@ -47,6 +49,8 @@ if (process.env.ENABLE_HTTPS_SERVER === "active") {
   app.use('/api/thumbRatings', thumbRatings);
   app.use('/api/streamSources', streamSources);
   app.use('/api/streamRatings', streamRatings);
+  app.use('/api/trendingTitles', trendingTitles);
+  app.use('/api/spielbergTitles', spielbergTitles);
 
   connectDB();
 

--- a/server/routes/spielbergTitlesRoutes.js
+++ b/server/routes/spielbergTitlesRoutes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const spielbergTitlesControllers = require("../../database/controllers/spielbergTitles.js");
+
+router.get("/", spielbergTitlesControllers.findSpielbergTitles);
+
+module.exports = router;

--- a/server/routes/titleDetailsRoutes.js
+++ b/server/routes/titleDetailsRoutes.js
@@ -1,56 +1,66 @@
+// const express = require("express");
+// const router = express.Router();
+// const axios = require('axios').default;
+
+// router.get("/", async (req, res) => {
+//   let search_field;
+//   if (req.query.type === 'tv') {
+//     search_field = 'tmdb_tv_id'
+//   } else if (req.query.type === 'movie') {
+//     search_field = 'tmdb_movie_id'
+//   } else {
+//     res.status(400).send('Invalid \'type\' input in search query.  Acceptable options are \'tv\' or \'movie\'')
+//   }
+
+//   await axios.get(`https://api.watchmode.com/v1/search/`, {
+//       params: {
+//         apiKey: process.env.WATCHMODE_API_KEY,
+//         search_field: search_field,
+//         search_value: req.query.tmdb_id,
+//         types: 'tv,movie'
+//       }
+//     })
+//       .then(async (response) => {
+//         let imdb_id = response.data.title_results[0].imdb_id;
+
+//         await axios.get(`http://www.omdbapi.com/`, {
+//           params: {
+//             apikey: process.env.OMDB_API_KEY,
+//             i: imdb_id,
+//             plot: 'full'
+//           }
+//         })
+//           .then((response) => {
+
+//             let newResponse = {
+//               title: response.data.Title,
+//               poster_path: response.data.Poster,
+//               ratings: response.data.Ratings,
+//               run_time: response.data.Runtime,
+//               director: response.data.Director,
+//               synopsis: response.data.Plot,
+//               type: req.query.type,
+//               tmdb_id: req.query.tmdb_id,
+//               parental_rating: response.data.Rated,
+//               release_date: response.data.Released,
+//               genre: response.data.genre
+//             }
+//             res.status(200).send(newResponse)
+//           })
+//       })
+//       .catch((error) => {
+//         res.status(400).send('Error while fetching IMDB ID from watchmode API: ' + error)
+//       })
+// });
+
+// module.exports = router;
+
+
+
 const express = require("express");
 const router = express.Router();
-const axios = require('axios').default;
+const titleDetailsControllers = require("../../database/controllers/titleDetails.js");
 
-router.get("/", async (req, res) => {
-  let search_field;
-  if (req.query.type === 'tv') {
-    search_field = 'tmdb_tv_id'
-  } else if (req.query.type === 'movie') {
-    search_field = 'tmdb_movie_id'
-  } else {
-    res.status(400).send('Invalid \'type\' input in search query.  Acceptable options are \'tv\' or \'movie\'')
-  }
-
-  await axios.get(`https://api.watchmode.com/v1/search/`, {
-      params: {
-        apiKey: process.env.WATCHMODE_API_KEY,
-        search_field: search_field,
-        search_value: req.query.tmdb_id,
-        types: 'tv,movie'
-      }
-    })
-      .then(async (response) => {
-        let imdb_id = response.data.title_results[0].imdb_id;
-
-        await axios.get(`http://www.omdbapi.com/`, {
-          params: {
-            apikey: process.env.OMDB_API_KEY,
-            i: imdb_id,
-            plot: 'full'
-          }
-        })
-          .then((response) => {
-
-            let newResponse = {
-              title: response.data.Title,
-              poster_path: response.data.Poster,
-              ratings: response.data.Ratings,
-              run_time: response.data.Runtime,
-              director: response.data.Director,
-              synopsis: response.data.Plot,
-              type: req.query.type,
-              tmdb_id: req.query.tmdb_id,
-              parental_rating: response.data.Rated,
-              release_date: response.data.Released,
-              genre: response.data.genre
-            }
-            res.status(200).send(newResponse)
-          })
-      })
-      .catch((error) => {
-        res.status(400).send('Error while fetching IMDB ID from watchmode API: ' + error)
-      })
-});
+router.get("/", titleDetailsControllers.findTitleDetails);
 
 module.exports = router;

--- a/server/routes/trendingTitlesRoutes.js
+++ b/server/routes/trendingTitlesRoutes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const trendingTitlesControllers = require("../../database/controllers/trendingTitles.js");
+
+router.get("/", trendingTitlesControllers.findTrendingTitles);
+
+module.exports = router;


### PR DESCRIPTION
All carousel-related routes return an additional property for each title ('saved_by_user') indicating whether or not the specific title is in the user's saved list.

Added 2 additional carousel routes:
GET /api/trendingTitles
GET /api/spielbergTitles
^^ Both of these routes can return duplicate titles from the user's saved list.  Can filter these out on the client side altogether or keep them and use the 'saved_by_user' property to dynamically render "Add" or "Remove" button

Refactored GET /api/titledetails route.  Now requires an additional query parameter ('user_id') and will return a property 'saved_by_user' indicating whether or not the specific title is in the user's saved list.

Also refactored GET /api/titledetails functionality to return the TMDB poster url instead of the OMDB poster url.  This  keeps the poster consistent with the carousel and search result posters