### PR TITLE
Refactored findTitleDetails controller 

### DIFF
--- a/database/controllers/titleDetails.js
+++ b/database/controllers/titleDetails.js
@@ -1,43 +1,47 @@
 const Saved_Title = require('../models/savedTitle.js');
 const axios = require('axios').default;
 
-
-const findTitleDetails = async (req, res) => {
-  let userSavedTitles = {};
-  let saved_by_user;
-
-  await Saved_Title.findOne({user_id: req.query.user_id, tmdb_id: req.query.tmdb_id})
+const findIfUserSaved = async (userId, tmdbId) => {
+  return Saved_Title.findOne({user_id: userId, tmdb_id: tmdbId})
     .then((savedTitle) => {
       if (savedTitle) {
-        saved_by_user = true
+        return Promise.resolve(true)
       } else {
-        saved_by_user = false
+        return Promise.resolve(false)
       }
     })
     .catch((error) => {
-      res.status(400).send('Error while looking up title in user\'s saved titles list: ' + error);
-      return;
+      return Promise.reject('Error while looking up title in user\'s saved titles list: ' + error);
     })
 
+}
+
+const findTextDetails = async (titleType, tmdbId) => {
+  let allDetails;
   let searchField;
-  if (req.query.type === 'tv') {
-    searchField = 'tmdb_tv_id';
-  } else if (req.query.type === 'movie') {
+  let hasError = false;
+  let errorMessage = '';
+
+  if (titleType === 'tv') {
+    searchField = 'tmdb_tv_id'
+  } else if (titleType === 'movie') {
     searchField = 'tmdb_movie_id'
   } else {
-    res.status(400).send('Invalid \'type\' input in search query.  Acceptable options are \'tv\' or \'movie\'');
-    return;
+    return('Invalid \'type\' input in search query.  Acceptable options are \'tv\' or \'movie\'');
   }
 
   await axios.get(`https://api.watchmode.com/v1/search/`, {
-      params: {
-        apiKey: process.env.WATCHMODE_API_KEY,
-        search_field: searchField,
-        search_value: req.query.tmdb_id,
-        types: 'tv,movie'
-      }
-    })
-      .then(async (watchmodeResponse) => {
+    params: {
+      apiKey: process.env.WATCHMODE_API_KEY,
+      search_field: searchField,
+      search_value: tmdbId,
+      types: 'tv,movie'
+    }
+  })
+    .then(async (watchmodeResponse) => {
+      if (watchmodeResponse.data.title_results.length === 0) {
+        return Promise.reject(`TMDB ID ${tmdbId} did not return a matching IMDB ID from the Watchmode API`)
+      } else {
         let imdb_id = watchmodeResponse.data.title_results[0].imdb_id;
 
         await axios.get(`http://www.omdbapi.com/`, {
@@ -59,61 +63,96 @@ const findTitleDetails = async (req, res) => {
                 }
               })
                 .then((newOmdbResponse) => {
-                  newResponse = {
+                  allDetails = {
                     title: newOmdbResponse.data.Title,
                     ratings: newOmdbResponse.data.Ratings,
                     run_time: newOmdbResponse.data.Runtime,
                     director: newOmdbResponse.data.Director,
                     synopsis: newOmdbResponse.data.Plot,
-                    type: req.query.type,
-                    tmdb_id: req.query.tmdb_id,
+                    type: titleType,
+                    tmdb_id: tmdbId,
                     parental_rating: newOmdbResponse.data.Rated,
                     release_date: newOmdbResponse.data.Released,
-                    genre: newOmdbResponse.data.genre,
-                    poster_path: 'https://i.imgur.com/7sR45d6.png',
-                    saved_by_user
+                    genre: newOmdbResponse.data.genre
                   }
                 })
+                .catch((error) => {
+                  hasError = true;
+                  errorMessage = 'Error fetching title details from OMDB API: ' + error.response.data.Error;
+                })
             } else {
-              newResponse = {
+              allDetails = {
                 title: omdbResponse.data.Title,
                 ratings: omdbResponse.data.Ratings,
                 run_time: omdbResponse.data.Runtime,
                 director: omdbResponse.data.Director,
                 synopsis: omdbResponse.data.Plot,
-                type: req.query.type,
-                tmdb_id: req.query.tmdb_id,
+                type: titleType,
+                tmdb_id: tmdbId,
                 parental_rating: omdbResponse.data.Rated,
                 release_date: omdbResponse.data.Released,
-                genre: omdbResponse.data.genre,
-                poster_path: 'https://i.imgur.com/7sR45d6.png',
-                saved_by_user
+                genre: omdbResponse.data.genre
               }
             }
-
-
-            await axios.get(`https://api.themoviedb.org/3/${req.query.type}/${req.query.tmdb_id}`, {
-              params: {
-                api_key: process.env.TMDB_API_KEY
-              }
-            })
-              .then((tmdbResponse) => {
-                if (tmdbResponse && tmdbResponse.data.poster_path) {
-                  newResponse.poster_path = `https://image.tmdb.org/t/p/w500${tmdbResponse.data.poster_path}`
-                }
-              })
-              .catch((error) => {
-                res.status(400).send('Error while retrieving poster from TMDB API: ' + error);
-                return;
-              })
-
-            res.status(200).send(newResponse)
           })
-      })
-      .catch((error) => {
-        res.status(400).send('Error while fetching IMDB ID from watchmode API: ' + error);
-        return;
-      })
+          .catch((error) => {
+            hasError = true;
+            errorMessage = 'Error fetching title details from OMDB API: ' + error.response.data.Error;
+          })
+      }
+    })
+    .catch((error) => {
+      hasError = true;
+      errorMessage = 'Error fetching imdb_id from Watchmode API: ' + error.response.data.statusMessage;
+    })
+
+    if (hasError) {
+      return Promise.reject(errorMessage);
+    } else {
+      return Promise.resolve(allDetails);
+    }
+}
+
+const findPosterUrl = async (titleType, tmdbId) => {
+  return axios.get(`https://api.themoviedb.org/3/${titleType}/${tmdbId}`, {
+    params: {
+      api_key: process.env.TMDB_API_KEY
+    }
+  })
+    .then((tmdbResponse) => {
+      if (tmdbResponse && tmdbResponse.data.poster_path) {
+        return Promise.resolve(`https://image.tmdb.org/t/p/w500${tmdbResponse.data.poster_path}`)
+      } else {
+        return Promise.resolve('https://i.imgur.com/7sR45d6.png')
+      }
+    })
+    .catch((error) => {
+      return Promise.reject('Error while retrieving poster from TMDB API: ' + error.response.data.status_message);
+    })
+
+}
+
+
+const findTitleDetails = async (req, res) => {
+  let errMessage;
+  let result;
+  await Promise.all(
+    [
+      findIfUserSaved(req.query.user_id, req.query.tmdb_id),
+      findTextDetails(req.query.type, req.query.tmdb_id),
+      findPosterUrl(req.query.type, req.query.tmdb_id)
+    ]
+  )
+  .then((allResults) => {
+    let allDetails = {...allResults[1]};
+    allDetails.saved_by_user = allResults[0];
+    allDetails.poster_path = allResults[2];
+    res.status(200).send(allDetails);
+  })
+  .catch((error) => {
+    res.status(400).send(error);
+    return;
+  })
 
 }
 


### PR DESCRIPTION
Refactored findTitleDetails controller to use Promise.all and execute axios requests concurrently instead of sequentially (reduced latency by 200ms locally):
<img width="523" alt="2022-01-11_07-56-01 (7)" src="https://user-images.githubusercontent.com/70612651/148966106-9d0c841c-7bef-49b6-90e2-da799bd72c5f.png">

Also added more specific error messages into findTitleDetails.  API will now return which specific request failed and what the error was (usually invalid API keys):
<img width="771" alt="2022-01-11_07-56-01 (10)" src="https://user-images.githubusercontent.com/70612651/148966359-80375646-bfcc-438b-a5d9-b1c893e54774.png">
